### PR TITLE
Fix Tailwind integration

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
-//= link_directory ../stylesheets .css//= link_tree ../builds
+//= link_directory ../stylesheets .css
+//= link_tree ../builds

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <title>アプリ名</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
+    <script src="https://cdn.tailwindcss.com"></script>
     <%= javascript_importmap_tags %>
   </head>
 


### PR DESCRIPTION
## Summary
- load Tailwind from CDN instead of missing build file
- correct manifest.js so assets are linked properly

## Testing
- `bin/rails test` *(fails: rbenv: version `3.4.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854c5405170832b8612f25ab0882ffe