### PR TITLE
feat: 投稿とコメントに投票機能を追加

### DIFF
--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -1,0 +1,26 @@
+class VotesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_votable
+
+  def vote
+    vote = @votable.votes.find_or_initialize_by(user: current_user)
+    new_value = params[:value].to_i
+
+    if vote.value == new_value
+      # 同じボタンを再度クリックした場合は投票を削除
+      vote.destroy
+    else
+      # 新規投票または投票の変更
+      vote.update(value: new_value)
+    end
+
+    redirect_back(fallback_location: root_path)
+  end
+
+  private
+
+  def set_votable
+    votable_type = params[:votable_type].classify.constantize
+    @votable = votable_type.find(params[:votable_id])
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,6 +2,8 @@ class Comment < ApplicationRecord
   belongs_to :post
   belongs_to :user, optional: true
 
+  has_many :votes, as: :votable, dependent: :destroy
+
   # 自己結合（コメントの返信用）
   belongs_to :parent, class_name: "Comment", optional: true
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -14,6 +14,7 @@ class Post < ApplicationRecord
   validate :validate_thumbnail_format
   
   has_many :comments, dependent: :destroy
+  has_many :votes, as: :votable, dependent: :destroy
   belongs_to :user, optional: true
   # validates :video, presence: true  # この行をコメントアウトして無効にする
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   # 投稿・コメント関連
   has_many :comments, dependent: :destroy
   has_many :posts
+  has_many :votes, dependent: :destroy
 
   # DM機能に必要な関連
   has_many :entries

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -1,0 +1,7 @@
+class Vote < ApplicationRecord
+  belongs_to :user
+  belongs_to :votable, polymorphic: true
+
+  validates :user_id, uniqueness: { scope: [:votable_type, :votable_id] }
+  validates :value, inclusion: { in: [-1, 1] }
+end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,17 @@
-<div class="comment">
-  <p><%= comment.body %></p>
-  <small><%= comment.created_at.strftime("%Y-%m-%d %H:%M") %></small>
+<div class="comment mb-4 p-3 bg-gray-50 rounded-lg">
+  <p class="text-gray-800"><%= comment.body %></p>
+  <div class="flex items-center justify-between mt-2">
+    <small class="text-gray-500"><%= comment.created_at.strftime("%Y-%m-%d %H:%M") %></small>
+    <div class="flex items-center gap-3">
+      <%= button_to vote_path(votable_type: 'Comment', votable_id: comment.id, value: 1), method: :post, class: "text-gray-400 hover:text-green-500" do %>
+        👍
+      <% end %>
+      <span class="text-gray-600 font-semibold text-sm">
+        <%= comment.votes.where(value: 1).count - comment.votes.where(value: -1).count %>
+      </span>
+      <%= button_to vote_path(votable_type: 'Comment', votable_id: comment.id, value: -1), method: :post, class: "text-gray-400 hover:text-red-500" do %>
+        👎
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/posts/_post_card.html.erb
+++ b/app/views/posts/_post_card.html.erb
@@ -8,7 +8,18 @@
       <% end %>
     </div>
   <% end %>
-  <div class="text-right">
+  <div class="flex items-center justify-between mt-4">
+    <div class="flex items-center gap-4">
+      <%= button_to vote_path(votable_type: 'Post', votable_id: post.id, value: 1), method: :post, class: "text-gray-500 hover:text-green-500" do %>
+        👍
+      <% end %>
+      <span class="text-gray-600 font-semibold">
+        <%= post.votes.where(value: 1).count - post.votes.where(value: -1).count %>
+      </span>
+      <%= button_to vote_path(votable_type: 'Post', votable_id: post.id, value: -1), method: :post, class: "text-gray-500 hover:text-red-500" do %>
+        👎
+      <% end %>
+    </div>
     <%= link_to "詳細を見る", post_path(post), class: "text-blue-500 hover:text-blue-700 font-semibold" %>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -39,6 +39,19 @@
     <span class="font-semibold text-gray-600">タグ:</span>
     <span class="bg-blue-50 text-blue-500 px-2 py-1 rounded-full text-sm"><%= @post.tag %></span>
   </p>
+
+  <!-- 投票ボタン -->
+  <div class="flex items-center justify-end gap-4 mt-6 border-t pt-4">
+    <%= button_to vote_path(votable_type: 'Post', votable_id: @post.id, value: 1), method: :post, class: "text-gray-500 hover:text-green-500" do %>
+      👍
+    <% end %>
+    <span class="text-gray-600 font-semibold">
+      <%= @post.votes.where(value: 1).count - @post.votes.where(value: -1).count %>
+    </span>
+    <%= button_to vote_path(votable_type: 'Post', votable_id: @post.id, value: -1), method: :post, class: "text-gray-500 hover:text-red-500" do %>
+      👎
+    <% end %>
+  </div>
 </div>
 
 <div class="max-w-2xl mx-auto mt-8">
@@ -51,6 +64,19 @@
         <span class="text-xs text-gray-400"><%= comment.created_at.strftime("%Y-%m-%d %H:%M") %></span>
       </div>
       <p class="mb-3 text-gray-800"><%= comment.body %></p>
+
+      <!-- 投票ボタン -->
+      <div class="flex items-center justify-end gap-3 text-sm">
+        <%= button_to vote_path(votable_type: 'Comment', votable_id: comment.id, value: 1), method: :post, class: "text-gray-400 hover:text-green-500" do %>
+          👍
+        <% end %>
+        <span class="text-gray-600 font-semibold">
+          <%= comment.votes.where(value: 1).count - comment.votes.where(value: -1).count %>
+        </span>
+        <%= button_to vote_path(votable_type: 'Comment', votable_id: comment.id, value: -1), method: :post, class: "text-gray-400 hover:text-red-500" do %>
+          👎
+        <% end %>
+      </div>
       
       <!-- 返信フォーム -->
       <%= form_with model: [@post, Comment.new], local: true, class: "flex gap-2 mb-2" do |f| %>
@@ -69,6 +95,18 @@
                 <span class="text-xs text-gray-400"><%= reply.created_at.strftime("%Y-%m-%d %H:%M") %></span>
               </div>
               <p class="text-gray-700"><%= reply.body %></p>
+              <!-- 投票ボタン -->
+              <div class="flex items-center justify-end gap-2 text-xs mt-1">
+                <%= button_to vote_path(votable_type: 'Comment', votable_id: reply.id, value: 1), method: :post, class: "text-gray-400 hover:text-green-500" do %>
+                  👍
+                <% end %>
+                <span class="text-gray-500 font-semibold">
+                  <%= reply.votes.where(value: 1).count - reply.votes.where(value: -1).count %>
+                </span>
+                <%= button_to vote_path(votable_type: 'Comment', votable_id: reply.id, value: -1), method: :post, class: "text-gray-400 hover:text-red-500" do %>
+                  👎
+                <% end %>
+              </div>
             </div>
           <% end %>
         </div>

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -21,6 +21,9 @@
     <p>保有コイン: <%= current_user.coins %></p>
     <p>ランク: <%= current_user.rank %></p>
     <p>ランクポイント: <%= current_user.rank_points %></p>
+    <div class="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
+      <div class="bg-blue-600 h-2.5 rounded-full" style="width: <%= current_user.rank_points %>%"></div>
+    </div>
 
     <% if user_signed_in? %>
       <%= render partial: "profile", locals: { user: current_user, posts: @posts } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,9 @@ Rails.application.routes.draw do
     resources :comments, only: [:create]
   end
 
+  # 投票機能
+  post 'vote', to: 'votes#vote'
+
   # 投稿検索
   get "posts/search", to: "posts#search", as: :search_posts
 

--- a/db/migrate/20250703024807_create_votes.rb
+++ b/db/migrate/20250703024807_create_votes.rb
@@ -1,0 +1,11 @@
+class CreateVotes < ActiveRecord::Migration[8.0]
+  def change
+    create_table :votes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :votable, polymorphic: true, null: false
+      t.integer :value
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_01_145847) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_03_024807) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -128,6 +128,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_01_145847) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "votes", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "votable_type", null: false
+    t.integer "votable_id", null: false
+    t.integer "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_votes_on_user_id"
+    t.index ["votable_type", "votable_id"], name: "index_votes_on_votable"
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "posts"
@@ -138,4 +149,5 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_01_145847) do
   add_foreign_key "messages", "users"
   add_foreign_key "preferences", "users"
   add_foreign_key "supporter_profiles", "users"
+  add_foreign_key "votes", "users"
 end


### PR DESCRIPTION
- 投稿とコメントにポジティブ/ネガティブの投票ボタンを設置
- 投票数を表示し、非同期で更新できるように実装
- 投票処理のためのVoteモデル、コントローラー、ルーティングを追加
- ユーザーのランクポイントをマイページでゲージ表示するように変更