### PR TITLE
feat: コメント数と本文の表示位置を調整

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -36,6 +36,10 @@
 <% if @posts.any? %>
   <% @posts.each do |post| %>
     <div class="<%= post_card_class(post) %>">
+      <p class="text-gray-500 mb-2 text-lg">
+        👤 <%= link_to post.user.name, user_path(post.user), class: "text-indigo-600 hover:underline" %>
+      </p>
+
       <h3 class="text-xl font-bold text-indigo-700 mb-2">
         <%= link_to post.title, post_path(post) %>
       </h3>
@@ -46,11 +50,7 @@
         </p>
       <% end %>
 
-      <p class="text-gray-500 text-sm mb-2">
-        投稿者: <%= link_to post.user.name, user_path(post.user), class: "text-indigo-600 hover:underline" %>
-      </p>
-
-      <p class="mb-4"><%= truncate(post.body, length: 100) %></p>
+      <p class="mb-4 ml-4"><%= truncate(post.body, length: 100) %></p>
 
       <% if post.tag.present? %>
         <div class="flex flex-wrap gap-2">
@@ -79,22 +79,9 @@
         </div>
       <% end %>
 
-      <p class="text-sm text-gray-500">コメント数: <%= post.comments.count %></p>
-
-      <!-- コメントフォーム -->
-      <div class="mt-4">
-        <%= form_with model: [post, post.comments.build], url: post_comments_path(post), local: true do |form| %>
-          <div>
-            
-            <%= form.text_area :body, rows: 2, placeholder: "コメントを追加...", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 bg-gray-50 p-2" %>
-          </div>
-          <div class="mt-2">
-            
-            <%= form.file_field :attachments, multiple: true, class: "mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100" %>
-          </div>
-          <div class="mt-2">
-            <%= form.submit "コメントする", class: "bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded" %>
-          </div>
+      <div class="flex items-center mt-4">
+        <%= link_to post_path(post), class: "flex items-center text-gray-500 text-2xl text-blue-500 hover:text-blue-700 ml-4" do %>
+          💬 <span class="ml-1"><%= post.comments.count %></span>
         <% end %>
       </div>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -69,7 +69,7 @@
       
       <%= f.file_field :attachments, multiple: true, class: "mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100" %>
     </div>
-    <div>
+    <div class="text-right">
       <%= f.submit "コメントする", class: "inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2" %>
     </div>
   <% end %>


### PR DESCRIPTION
- ホームページの投稿一覧で、コメント数をクリックすると投稿詳細に遷移するように変更。
- コメントアイコンの表示を削除。
- コメント数と投稿本文の表示位置を調整し、視認性を向上。
- 投稿詳細ページのコメント投稿ボタンを右寄せに調整。